### PR TITLE
Use Standard_A1_v2 instead of Standard_A1 for the azurerm_virtual_machine

### DIFF
--- a/modules/azure/main.tf
+++ b/modules/azure/main.tf
@@ -87,7 +87,7 @@ resource "azurerm_virtual_machine" "virtual_machine" {
   location                         = var.location
   resource_group_name              = azurerm_resource_group.resource_group.name
   network_interface_ids            = [azurerm_network_interface.network_interface.id]
-  vm_size                          = "Standard_A1"
+  vm_size                          = "Standard_A1_v2"
   delete_os_disk_on_termination    = true
   delete_data_disks_on_termination = true
 


### PR DESCRIPTION
I don't think this is available, or at least not available for trial accounts right now

I got this error after running `terraform apply`
```
│ Error: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="SkuNotAvailable" Message="The requested size for resource '/subscriptions/6e1e9c04-876e-49bf-be7e-da7e1c0d0d76/resourceGroups/7amjxydjxjnqj9t58jk4kkeb/providers/Microsoft.Compute/virtualMachines/azure-vm' is currently not available in location 'westus2' zones '' for subscription '6e1e9c04-876e-49bf-be7e-da7e1c0d0d76'. Please try another size or deploy to a different location or zones. See https://aka.ms/azureskunotavailable for details."
│ 
│   with module.azure.azurerm_virtual_machine.virtual_machine,
│   on .terraform/modules/azure/modules/azure/main.tf line 85, in resource "azurerm_virtual_machine" "virtual_machine":
│   85: resource "azurerm_virtual_machine" "virtual_machine" {
│ 
╵
```

```
Dustins-MBP:part1_hybridcloud-lb dustinalandzes$ az vm list-skus --size Standard_A1 --all --output table
ResourceType     Locations           Name            Zones    Restrictions
---------------  ------------------  --------------  -------  ------------------------------------------------------------------------------------------------------------------------------------------------------------------
virtualMachines  AustraliaCentral    Standard_A1              NotAvailableForSubscription, type: Location, locations: AustraliaCentral
virtualMachines  AustraliaCentral2   Standard_A1              NotAvailableForSubscription, type: Location, locations: AustraliaCentral2
virtualMachines  australiaeast       Standard_A1              ['NotAvailableForSubscription, type: Location, locations: australiaeast', 'NotAvailableForSubscription, type: Zone, locations: australiaeast, zones: 1,2,3']
virtualMachines  australiasoutheast  Standard_A1              NotAvailableForSubscription, type: Location, locations: australiasoutheast
virtualMachines  brazilsouth         Standard_A1              ['NotAvailableForSubscription, type: Location, locations: brazilsouth', 'NotAvailableForSubscription, type: Zone, locations: brazilsouth, zones: 1,2,3']
virtualMachines  CanadaCentral       Standard_A1              ['NotAvailableForSubscription, type: Location, locations: CanadaCentral', 'NotAvailableForSubscription, type: Zone, locations: CanadaCentral, zones: 1,2,3']
virtualMachines  CanadaEast          Standard_A1              NotAvailableForSubscription, type: Location, locations: CanadaEast
virtualMachines  CentralIndia        Standard_A1              ['NotAvailableForSubscription, type: Location, locations: CentralIndia', 'NotAvailableForSubscription, type: Zone, locations: CentralIndia, zones: 1,2,3']
virtualMachines  centralus           Standard_A1              ['NotAvailableForSubscription, type: Location, locations: centralus', 'NotAvailableForSubscription, type: Zone, locations: centralus, zones: 1,2,3']
virtualMachines  CentralUSEUAP       Standard_A1              NotAvailableForSubscription, type: Location, locations: CentralUSEUAP
virtualMachines  eastasia            Standard_A1              NotAvailableForSubscription, type: Location, locations: eastasia
virtualMachines  eastus              Standard_A1              ['NotAvailableForSubscription, type: Location, locations: eastus', 'NotAvailableForSubscription, type: Zone, locations: eastus, zones: 1,2,3']
virtualMachines  eastus2             Standard_A1              ['NotAvailableForSubscription, type: Location, locations: eastus2', 'NotAvailableForSubscription, type: Zone, locations: eastus2, zones: 1,2,3']
virtualMachines  EastUS2EUAP         Standard_A1              ['NotAvailableForSubscription, type: Location, locations: EastUS2EUAP', 'NotAvailableForSubscription, type: Zone, locations: EastUS2EUAP, zones: 1,2,3']
virtualMachines  FranceCentral       Standard_A1              ['NotAvailableForSubscription, type: Location, locations: FranceCentral', 'NotAvailableForSubscription, type: Zone, locations: FranceCentral, zones: 1,2,3']
virtualMachines  FranceSouth         Standard_A1              NotAvailableForSubscription, type: Location, locations: FranceSouth
virtualMachines  japaneast           Standard_A1              ['NotAvailableForSubscription, type: Location, locations: japaneast', 'NotAvailableForSubscription, type: Zone, locations: japaneast, zones: 1,2,3']
virtualMachines  japanwest           Standard_A1              NotAvailableForSubscription, type: Location, locations: japanwest
virtualMachines  KoreaCentral        Standard_A1              ['NotAvailableForSubscription, type: Location, locations: KoreaCentral', 'NotAvailableForSubscription, type: Zone, locations: KoreaCentral, zones: 1,2,3']
virtualMachines  KoreaSouth          Standard_A1              NotAvailableForSubscription, type: Location, locations: KoreaSouth
virtualMachines  northcentralus      Standard_A1              NotAvailableForSubscription, type: Location, locations: northcentralus
virtualMachines  northeurope         Standard_A1              ['NotAvailableForSubscription, type: Location, locations: northeurope', 'NotAvailableForSubscription, type: Zone, locations: northeurope, zones: 1,2,3']
virtualMachines  SouthAfricaNorth    Standard_A1              ['NotAvailableForSubscription, type: Location, locations: SouthAfricaNorth', 'NotAvailableForSubscription, type: Zone, locations: SouthAfricaNorth, zones: 1,2,3']
virtualMachines  SouthAfricaWest     Standard_A1              NotAvailableForSubscription, type: Location, locations: SouthAfricaWest
virtualMachines  southcentralus      Standard_A1              ['NotAvailableForSubscription, type: Location, locations: southcentralus', 'NotAvailableForSubscription, type: Zone, locations: southcentralus, zones: 1,2,3']
virtualMachines  southeastasia       Standard_A1              ['NotAvailableForSubscription, type: Location, locations: southeastasia', 'NotAvailableForSubscription, type: Zone, locations: southeastasia, zones: 1,2,3']
virtualMachines  SouthIndia          Standard_A1              NotAvailableForSubscription, type: Location, locations: SouthIndia
virtualMachines  UAECentral          Standard_A1              NotAvailableForSubscription, type: Location, locations: UAECentral
virtualMachines  UAENorth            Standard_A1              NotAvailableForSubscription, type: Location, locations: UAENorth
virtualMachines  uksouth             Standard_A1              ['NotAvailableForSubscription, type: Location, locations: uksouth', 'NotAvailableForSubscription, type: Zone, locations: uksouth, zones: 1,2,3']
virtualMachines  ukwest              Standard_A1              NotAvailableForSubscription, type: Location, locations: ukwest
virtualMachines  westcentralus       Standard_A1              NotAvailableForSubscription, type: Location, locations: westcentralus
virtualMachines  westeurope          Standard_A1              ['NotAvailableForSubscription, type: Location, locations: westeurope', 'NotAvailableForSubscription, type: Zone, locations: westeurope, zones: 1,2,3']
virtualMachines  WestIndia           Standard_A1              NotAvailableForSubscription, type: Location, locations: WestIndia
virtualMachines  westus              Standard_A1              NotAvailableForSubscription, type: Location, locations: westus
virtualMachines  westus2             Standard_A1              ['NotAvailableForSubscription, type: Location, locations: westus2', 'NotAvailableForSubscription, type: Zone, locations: westus2, zones: 1,2,3']
virtualMachines  AustraliaCentral    Standard_A1_v2           None
virtualMachines  AustraliaCentral2   Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: AustraliaCentral2
virtualMachines  australiaeast       Standard_A1_v2  1,2,3    None
virtualMachines  australiasoutheast  Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: australiasoutheast
virtualMachines  brazilsouth         Standard_A1_v2  1,2,3    None
virtualMachines  BrazilSoutheast     Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: BrazilSoutheast
virtualMachines  CanadaCentral       Standard_A1_v2  1,2,3    None
virtualMachines  CanadaEast          Standard_A1_v2           None
virtualMachines  CentralIndia        Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: CentralIndia
virtualMachines  centralus           Standard_A1_v2  1,2,3    None
virtualMachines  CentralUSEUAP       Standard_A1_v2  2        None
virtualMachines  eastasia            Standard_A1_v2           None
virtualMachines  eastus              Standard_A1_v2  1,2,3    None
virtualMachines  eastus2             Standard_A1_v2  1,2,3    NotAvailableForSubscription, type: Zone, locations: eastus2, zones: 1,2
virtualMachines  EastUS2EUAP         Standard_A1_v2  1,2,3    NotAvailableForSubscription, type: Zone, locations: EastUS2EUAP, zones: 1,2
virtualMachines  EastUSSTG           Standard_A1_v2           None
virtualMachines  FranceCentral       Standard_A1_v2  1,2,3    None
virtualMachines  FranceSouth         Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: FranceSouth
virtualMachines  GermanyNorth        Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: GermanyNorth
virtualMachines  GermanyWestCentral  Standard_A1_v2  1,2,3    None
virtualMachines  japaneast           Standard_A1_v2  1,2,3    None
virtualMachines  japanwest           Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: japanwest
virtualMachines  JioIndiaCentral     Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: JioIndiaCentral
virtualMachines  JioIndiaWest        Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: JioIndiaWest
virtualMachines  KoreaCentral        Standard_A1_v2  1,2,3    None
virtualMachines  KoreaSouth          Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: KoreaSouth
virtualMachines  northcentralus      Standard_A1_v2           None
virtualMachines  northeurope         Standard_A1_v2  1,2,3    None
virtualMachines  NorwayEast          Standard_A1_v2  1,2,3    None
virtualMachines  NorwayWest          Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: NorwayWest
virtualMachines  QatarCentral        Standard_A1_v2           None
virtualMachines  SouthAfricaNorth    Standard_A1_v2  1,2,3    NotAvailableForSubscription, type: Zone, locations: SouthAfricaNorth, zones: 1,2,3
virtualMachines  SouthAfricaWest     Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: SouthAfricaWest
virtualMachines  southcentralus      Standard_A1_v2  1,2,3    ['NotAvailableForSubscription, type: Location, locations: southcentralus', 'NotAvailableForSubscription, type: Zone, locations: southcentralus, zones: 1,2,3']
virtualMachines  SouthCentralUSSTG   Standard_A1_v2           None
virtualMachines  southeastasia       Standard_A1_v2  1,2,3    NotAvailableForSubscription, type: Zone, locations: southeastasia, zones: 1
virtualMachines  SouthIndia          Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: SouthIndia
virtualMachines  SwedenCentral       Standard_A1_v2           None
virtualMachines  SwedenSouth         Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: SwedenSouth
virtualMachines  SwitzerlandNorth    Standard_A1_v2           None
virtualMachines  SwitzerlandWest     Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: SwitzerlandWest
virtualMachines  UAECentral          Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: UAECentral
virtualMachines  UAENorth            Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: UAENorth
virtualMachines  uksouth             Standard_A1_v2  1,2,3    None
virtualMachines  ukwest              Standard_A1_v2           None
virtualMachines  westcentralus       Standard_A1_v2           None
virtualMachines  westeurope          Standard_A1_v2  1,2,3    None
virtualMachines  WestIndia           Standard_A1_v2           NotAvailableForSubscription, type: Location, locations: WestIndia
virtualMachines  westus              Standard_A1_v2           None
virtualMachines  westus2             Standard_A1_v2  1,2,3    None
virtualMachines  WestUS3             Standard_A1_v2  1,2,3    None
```