### PR TITLE
Changed LB port

### DIFF
--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -9,7 +9,7 @@ resource "docker_container" "loadbalancer" {
   ]
   ports {
     internal = 80
-    external = 5000
+    external = 5999
   }
 }
 

--- a/modules/loadbalancer/outputs.tf
+++ b/modules/loadbalancer/outputs.tf
@@ -1,3 +1,3 @@
 output "network_address" {
-  value = "localhost:5000"
+  value = "localhost:5999"
 }


### PR DESCRIPTION
Changed LB port as macOS Monterey ControlCenter holds port 5000.

Apparently Apple has decided to use port 5000 for some new AirPlay functionality.

https://developer.apple.com/forums/thread/682332