### PR TITLE
Update gcp ubuntu version to 2204

### DIFF
--- a/modules/gcp/main.tf
+++ b/modules/gcp/main.tf
@@ -37,7 +37,7 @@ resource "google_compute_instance" "compute_instance" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-1804-lts"
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
     }
   }
 


### PR DESCRIPTION
PR for [issue 4](https://github.com/terraform-in-action/terraform-cloud-vm/issues/4)

When running `terraform apply` my gcp module could not find the 1804-lts
> │ Error: Error resolving image name 'ubuntu-os-cloud/ubuntu-1804-lts': Could not find image or family ubuntu-os-cloud/ubuntu-1804-lts
│
│   with module.gcp.google_compute_instance.compute_instance,
│   on .terraform/modules/gcp/modules/gcp/main.tf line 32, in resource "google_compute_instance" "compute_instance":
│   32: resource "google_compute_instance" "compute_instance" { 


Running the find image command from https://ubuntu.com/server/docs/cloud-images/google-cloud-engine
`gcloud compute images list --filter ubuntu-os-cloud`

```
NAME                                       PROJECT          FAMILY                         DEPRECATED  STATUS
ubuntu-2004-focal-arm64-v20230918          ubuntu-os-cloud  ubuntu-2004-lts-arm64                      READY
ubuntu-2004-focal-v20230918                ubuntu-os-cloud  ubuntu-2004-lts                            READY
ubuntu-2204-jammy-arm64-v20230919          ubuntu-os-cloud  ubuntu-2204-lts-arm64                      READY
ubuntu-2204-jammy-v20230919                ubuntu-os-cloud  ubuntu-2204-lts                            READY
ubuntu-2304-lunar-amd64-v20231003          ubuntu-os-cloud  ubuntu-2304-amd64                          READY
ubuntu-2304-lunar-arm64-v20231003          ubuntu-os-cloud  ubuntu-2304-arm64                          READY
ubuntu-minimal-2004-focal-arm64-v20230919  ubuntu-os-cloud  ubuntu-minimal-2004-lts-arm64              READY
ubuntu-minimal-2004-focal-v20230919        ubuntu-os-cloud  ubuntu-minimal-2004-lts                    READY
ubuntu-minimal-2204-jammy-arm64-v20231003  ubuntu-os-cloud  ubuntu-minimal-2204-lts-arm64              READY
ubuntu-minimal-2204-jammy-v20231003        ubuntu-os-cloud  ubuntu-minimal-2204-lts                    READY
ubuntu-minimal-2304-lunar-amd64-v20230919  ubuntu-os-cloud  ubuntu-minimal-2304-amd64                  READY
ubuntu-minimal-2304-lunar-arm64-v20230919  ubuntu-os-cloud  ubuntu-minimal-2304-arm64                  READY
```
I don't get 1804-lts as a result anymore.

